### PR TITLE
chore: Updating koin to use maven instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.kotlin_version = '1.7.10'
     ext.koin_version = '3.2.1'
-    ext.timber_version = '4.7.1'
+    ext.timber_version = '5.0.1'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
@@ -20,7 +20,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.4.32'
-    ext.koin_version = '2.2.2'
+    ext.koin_version = '3.2.1'
     ext.timber_version = '4.7.1'
     repositories {
         google()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     defaultConfig {
         applicationId "quentin7b.com.github.kointimber"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 3
         versionName "2.0.0"
     }
@@ -25,7 +25,7 @@ dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation "org.koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
     implementation project(':kointimber')
 }

--- a/example/src/main/java/com/github/quentin7b/kointimber/ExampleActivity.kt
+++ b/example/src/main/java/com/github/quentin7b/kointimber/ExampleActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatTextView
-import org.koin.android.ext.android.inject
+import io.insert-koin.android.ext.android.inject
 
 class ExampleActivity : AppCompatActivity() {
 

--- a/example/src/main/java/com/github/quentin7b/kointimber/ExampleApp.kt
+++ b/example/src/main/java/com/github/quentin7b/kointimber/ExampleApp.kt
@@ -1,9 +1,9 @@
 package com.github.quentin7b.kointimber
 
 import android.app.Application
-import org.koin.android.ext.koin.androidContext
-import org.koin.core.context.startKoin
-import org.koin.dsl.module
+import io.insert-koin.android.ext.koin.androidContext
+import io.insert-koin.core.context.startKoin
+import io.insert-koin.dsl.module
 import timber.log.Timber
 
 class ExampleApp : Application() {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 17 15:19:53 CET 2019
+#Tue Sep 13 12:43:02 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/kointimber/build.gradle
+++ b/kointimber/build.gradle
@@ -27,6 +27,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
     implementation "com.jakewharton.timber:timber:$timber_version"
 }

--- a/kointimber/build.gradle
+++ b/kointimber/build.gradle
@@ -7,11 +7,11 @@ plugins {
 group = 'com.github.quentin7b'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 3
         versionName "2.0.0"
     }

--- a/kointimber/src/main/java/com/github/quentin7b/kointimber/TimberLogger.kt
+++ b/kointimber/src/main/java/com/github/quentin7b/kointimber/TimberLogger.kt
@@ -1,8 +1,8 @@
 package com.github.quentin7b.kointimber
 
-import org.koin.core.logger.Level
-import org.koin.core.logger.Logger
-import org.koin.core.logger.MESSAGE
+import io.insert-koin.core.logger.Level
+import io.insert-koin.core.logger.Logger
+import io.insert-koin.core.logger.MESSAGE
 import timber.log.Timber
 
 /**


### PR DESCRIPTION
Jcenter is now deprecated. This imports the new version of koin from maven central.